### PR TITLE
fix: index.py added dynamic path padding

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,6 +1,15 @@
 """
 Vercel Serverless entrypoint for FastAPI.
 """
+import os
+import sys
+from pathlib import Path
+
+# Fix: Add the 'api' directory to sys.path so that absolute imports work on Vercel
+api_dir = Path(__file__).parent.resolve()
+if str(api_dir) not in sys.path:
+    sys.path.append(str(api_dir))
+
 from server.main import app
 
 __all__ = ["app"]


### PR DESCRIPTION
This pull request makes a small but important change to the `api/index.py` file to ensure absolute imports work correctly when deployed on Vercel.

- Added logic to append the `api` directory to `sys.path` if it's not already present, fixing issues with absolute imports in the Vercel environment.