### PR TITLE
fix: sanitize blob filename + retry download #vercel-hardening

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,8 +64,25 @@ function getApiUrl(path: string) {
   return `${base}${path}`;
 }
 
+function sanitizeFilename(originalName: string) {
+  const fallbackBase = `exam-gen-${Date.now()}`;
+  const lastDotIndex = originalName.lastIndexOf(".");
+  const hasExtension = lastDotIndex > 0 && lastDotIndex < originalName.length - 1;
+  const extension = hasExtension ? originalName.slice(lastDotIndex) : ".pdf";
+  const baseName = hasExtension ? originalName.slice(0, lastDotIndex) : originalName;
+  const normalized = baseName
+    .normalize("NFKD")
+    .replace(/[^a-zA-Z0-9-_ ]+/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+  const safeBase = normalized || fallbackBase;
+  return `${safeBase}${extension}`;
+}
+
 async function uploadPdfToBlob(file: File) {
-  const result = await upload(file.name, file, {
+  const safeFilename = sanitizeFilename(file.name);
+  const result = await upload(safeFilename, file, {
     access: "public",
     handleUploadUrl: "/api/upload",
   });


### PR DESCRIPTION
This pull request improves the robustness of file downloading in the backend and adds filename sanitization for uploads in the frontend. The most important changes are:

**Backend: Improved File Download Reliability**

* Added retry logic with exponential backoff to the `download_blob` function in `main.py`, handling transient HTTP and network errors more gracefully and providing clearer error responses to the client.
* Imported the `asyncio` module in `main.py` to support asynchronous retries and delays in the download logic.

**Frontend: Safer Filename Handling**

* Introduced a `sanitizeFilename` function in `page.tsx` to normalize and clean uploaded filenames, ensuring only safe characters are used and preventing issues with special or invalid characters. This sanitized name is now used when uploading files to blob storage.